### PR TITLE
Trap IO exceptions from durable-queue---communicate to crawler.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cc.artifice/pegasus "0.6.8"
+(defproject cc.artifice/pegasus "0.6.9"
   :description "A scaleable production-ready crawler in clojure"
   :url "http://github.com/shriphani/pegasus"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
If the durable queue used for crawling tasks is corrupted, it will throw IO exceptions (its got a checksum calculation to test the queue for sanity).  Unfortunately, this was killing the asynchronous worker thread, and eventually, we were running out of async threads.  

This change catches java.io.IOException in the asynchronous queue worker thread, and updates the state of the crawl to include a :queue-error true entry.  Independently, the stop-check for a crawl tests for this condition--which happens in a different thread.  When :queue-error is true, the crawl stops, and the status for the crawl is set to "error."  On a subsequent crawl, the crawler will note that the last crawl failed, and delete the persistent state files for the crawl source.  This is my best hope for uncorrupting a corrupted source.